### PR TITLE
Migrate to Kibo UI contributions graph

### DIFF
--- a/components/contributions.tsx
+++ b/components/contributions.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import {
+  type Activity,
+  ContributionGraph,
+  ContributionGraphBlock,
+  ContributionGraphCalendar,
+  ContributionGraphFooter,
+  ContributionGraphLegend,
+  ContributionGraphTotalCount,
+} from "@/components/ui/kibo-ui/contribution-graph";
+import { cn } from "@/lib/utils";
+
+type ContributionsProps = {
+  data: Activity[];
+}
+
+export const Contributions = ({ data }: ContributionsProps) => (
+  <ContributionGraph data={data}>
+    <ContributionGraphCalendar>
+      {({ activity, dayIndex, weekIndex }) => (
+        <ContributionGraphBlock
+          activity={activity}
+          className={cn(
+            'data-[level="0"]:fill-[#eeeeee] dark:data-[level="0"]:fill-[#262626]',
+            'data-[level="1"]:fill-[#9be9a8] dark:data-[level="1"]:fill-[#0e4429]',
+            'data-[level="2"]:fill-[#40c463] dark:data-[level="2"]:fill-[#006d32]',
+            'data-[level="3"]:fill-[#30a14e] dark:data-[level="3"]:fill-[#26a641]',
+            'data-[level="4"]:fill-[#216e39] dark:data-[level="4"]:fill-[#39d353]'
+          )}
+          dayIndex={dayIndex}
+          weekIndex={weekIndex}
+        />
+      )}
+    </ContributionGraphCalendar>
+    <ContributionGraphFooter>
+      <ContributionGraphTotalCount />
+      <ContributionGraphLegend>
+        {({ level }) => (
+          <div
+            className="group relative flex h-3 w-3 items-center justify-center"
+            data-level={level}
+          >
+            <div
+              className={cn('h-full w-full rounded-xs border border-border',
+                level === 0 && "bg-[#eeeeee] dark:bg-[#262626]",
+                level === 1 && "bg-[#9be9a8] dark:bg-[#0e4429]",
+                level === 2 && "bg-[#40c463] dark:bg-[#006d32]",
+                level === 3 && "bg-[#30a14e] dark:bg-[#26a641]",
+                level === 4 && "bg-[#216e39] dark:bg-[#39d353]"
+              )}
+            />
+            <span className="-top-8 absolute hidden rounded bg-popover px-2 py-1 text-popover-foreground text-xs shadow-md group-hover:block">
+              Level {level}
+            </span>
+          </div>
+        )}
+      </ContributionGraphLegend>
+    </ContributionGraphFooter>
+  </ContributionGraph>
+)

--- a/components/contributions.tsx
+++ b/components/contributions.tsx
@@ -17,7 +17,7 @@ type ContributionsProps = {
 
 export const Contributions = ({ data }: ContributionsProps) => (
   <ContributionGraph data={data}>
-    <ContributionGraphCalendar>
+    <ContributionGraphCalendar className="overflow-hidden">
       {({ activity, dayIndex, weekIndex }) => (
         <ContributionGraphBlock
           activity={activity}

--- a/components/ui/kibo-ui/contribution-graph/index.tsx
+++ b/components/ui/kibo-ui/contribution-graph/index.tsx
@@ -1,0 +1,517 @@
+"use client";
+
+import type { Day as WeekDay } from "date-fns";
+import {
+  differenceInCalendarDays,
+  eachDayOfInterval,
+  formatISO,
+  getDay,
+  getMonth,
+  getYear,
+  nextDay,
+  parseISO,
+  subWeeks,
+} from "date-fns";
+import {
+  type CSSProperties,
+  createContext,
+  Fragment,
+  type HTMLAttributes,
+  type ReactNode,
+  useContext,
+  useMemo,
+} from "react";
+import { cn } from "@/lib/utils";
+
+export type Activity = {
+  date: string;
+  count: number;
+  level: number;
+};
+
+type Week = Array<Activity | undefined>;
+
+export type Labels = {
+  months?: string[];
+  weekdays?: string[];
+  totalCount?: string;
+  legend?: {
+    less?: string;
+    more?: string;
+  };
+};
+
+type MonthLabel = {
+  weekIndex: number;
+  label: string;
+};
+
+const DEFAULT_MONTH_LABELS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+const DEFAULT_LABELS: Labels = {
+  months: DEFAULT_MONTH_LABELS,
+  weekdays: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+  totalCount: "{{count}} activities in {{year}}",
+  legend: {
+    less: "Less",
+    more: "More",
+  },
+};
+
+type ContributionGraphContextType = {
+  data: Activity[];
+  weeks: Week[];
+  blockMargin: number;
+  blockRadius: number;
+  blockSize: number;
+  fontSize: number;
+  labels: Labels;
+  labelHeight: number;
+  maxLevel: number;
+  totalCount: number;
+  weekStart: WeekDay;
+  year: number;
+  width: number;
+  height: number;
+};
+
+const ContributionGraphContext =
+  createContext<ContributionGraphContextType | null>(null);
+
+const useContributionGraph = () => {
+  const context = useContext(ContributionGraphContext);
+
+  if (!context) {
+    throw new Error(
+      "ContributionGraph components must be used within a ContributionGraph"
+    );
+  }
+
+  return context;
+};
+
+const fillHoles = (activities: Activity[]): Activity[] => {
+  if (activities.length === 0) {
+    return [];
+  }
+
+  // Sort activities by date to ensure correct date range
+  const sortedActivities = [...activities].sort((a, b) =>
+    a.date.localeCompare(b.date)
+  );
+
+  const calendar = new Map<string, Activity>(
+    activities.map((a) => [a.date, a])
+  );
+
+  const firstActivity = sortedActivities[0] as Activity;
+  const lastActivity = sortedActivities.at(-1);
+
+  if (!lastActivity) {
+    return [];
+  }
+
+  return eachDayOfInterval({
+    start: parseISO(firstActivity.date),
+    end: parseISO(lastActivity.date),
+  }).map((day) => {
+    const date = formatISO(day, { representation: "date" });
+
+    if (calendar.has(date)) {
+      return calendar.get(date) as Activity;
+    }
+
+    return {
+      date,
+      count: 0,
+      level: 0,
+    };
+  });
+};
+
+const groupByWeeks = (
+  activities: Activity[],
+  weekStart: WeekDay = 0
+): Week[] => {
+  if (activities.length === 0) {
+    return [];
+  }
+
+  const normalizedActivities = fillHoles(activities);
+  const firstActivity = normalizedActivities[0] as Activity;
+  const firstDate = parseISO(firstActivity.date);
+  const firstCalendarDate =
+    getDay(firstDate) === weekStart
+      ? firstDate
+      : subWeeks(nextDay(firstDate, weekStart), 1);
+
+  const paddedActivities = [
+    ...(new Array(differenceInCalendarDays(firstDate, firstCalendarDate)).fill(
+      undefined
+    ) as Activity[]),
+    ...normalizedActivities,
+  ];
+
+  const numberOfWeeks = Math.ceil(paddedActivities.length / 7);
+
+  return new Array(numberOfWeeks)
+    .fill(undefined)
+    .map((_, weekIndex) =>
+      paddedActivities.slice(weekIndex * 7, weekIndex * 7 + 7)
+    );
+};
+
+const getMonthLabels = (
+  weeks: Week[],
+  monthNames: string[] = DEFAULT_MONTH_LABELS
+): MonthLabel[] => {
+  return weeks
+    .reduce<MonthLabel[]>((labels, week, weekIndex) => {
+      const firstActivity = week.find((activity) => activity !== undefined);
+
+      if (!firstActivity) {
+        throw new Error(
+          `Unexpected error: Week ${weekIndex + 1} is empty: [${week}].`
+        );
+      }
+
+      const month = monthNames[getMonth(parseISO(firstActivity.date))];
+
+      if (!month) {
+        const monthName = new Date(firstActivity.date).toLocaleString("en-US", {
+          month: "short",
+        });
+        throw new Error(
+          `Unexpected error: undefined month label for ${monthName}.`
+        );
+      }
+
+      const prevLabel = labels.at(-1);
+
+      if (weekIndex === 0 || !prevLabel || prevLabel.label !== month) {
+        return labels.concat({ weekIndex, label: month });
+      }
+
+      return labels;
+    }, [])
+    .filter(({ weekIndex }, index, labels) => {
+      const minWeeks = 3;
+
+      if (index === 0) {
+        return labels[1] && labels[1].weekIndex - weekIndex >= minWeeks;
+      }
+
+      if (index === labels.length - 1) {
+        return weeks.slice(weekIndex).length >= minWeeks;
+      }
+
+      return true;
+    });
+};
+
+export type ContributionGraphProps = HTMLAttributes<HTMLDivElement> & {
+  data: Activity[];
+  blockMargin?: number;
+  blockRadius?: number;
+  blockSize?: number;
+  fontSize?: number;
+  labels?: Labels;
+  maxLevel?: number;
+  style?: CSSProperties;
+  totalCount?: number;
+  weekStart?: WeekDay;
+  children: ReactNode;
+  className?: string;
+};
+
+export const ContributionGraph = ({
+  data,
+  blockMargin = 4,
+  blockRadius = 2,
+  blockSize = 12,
+  fontSize = 14,
+  labels: labelsProp = undefined,
+  maxLevel: maxLevelProp = 4,
+  style = {},
+  totalCount: totalCountProp = undefined,
+  weekStart = 0,
+  className,
+  ...props
+}: ContributionGraphProps) => {
+  const maxLevel = Math.max(1, maxLevelProp);
+  const weeks = useMemo(() => groupByWeeks(data, weekStart), [data, weekStart]);
+  const LABEL_MARGIN = 8;
+
+  const labels = { ...DEFAULT_LABELS, ...labelsProp };
+  const labelHeight = fontSize + LABEL_MARGIN;
+
+  const year =
+    data.length > 0
+      ? getYear(parseISO(data[0].date))
+      : new Date().getFullYear();
+
+  const totalCount =
+    typeof totalCountProp === "number"
+      ? totalCountProp
+      : data.reduce((sum, activity) => sum + activity.count, 0);
+
+  const width = weeks.length * (blockSize + blockMargin) - blockMargin;
+  const height = labelHeight + (blockSize + blockMargin) * 7 - blockMargin;
+
+  if (data.length === 0) {
+    return null;
+  }
+
+  return (
+    <ContributionGraphContext.Provider
+      value={{
+        data,
+        weeks,
+        blockMargin,
+        blockRadius,
+        blockSize,
+        fontSize,
+        labels,
+        labelHeight,
+        maxLevel,
+        totalCount,
+        weekStart,
+        year,
+        width,
+        height,
+      }}
+    >
+      <div
+        className={cn("flex w-max max-w-full flex-col gap-2", className)}
+        style={{ fontSize, ...style }}
+        {...props}
+      />
+    </ContributionGraphContext.Provider>
+  );
+};
+
+export type ContributionGraphBlockProps = HTMLAttributes<SVGRectElement> & {
+  activity: Activity;
+  dayIndex: number;
+  weekIndex: number;
+};
+
+export const ContributionGraphBlock = ({
+  activity,
+  dayIndex,
+  weekIndex,
+  className,
+  ...props
+}: ContributionGraphBlockProps) => {
+  const { blockSize, blockMargin, blockRadius, labelHeight, maxLevel } =
+    useContributionGraph();
+
+  if (activity.level < 0 || activity.level > maxLevel) {
+    throw new RangeError(
+      `Provided activity level ${activity.level} for ${activity.date} is out of range. It must be between 0 and ${maxLevel}.`
+    );
+  }
+
+  return (
+    <rect
+      className={cn(
+        'data-[level="0"]:fill-muted',
+        'data-[level="1"]:fill-muted-foreground/20',
+        'data-[level="2"]:fill-muted-foreground/40',
+        'data-[level="3"]:fill-muted-foreground/60',
+        'data-[level="4"]:fill-muted-foreground/80',
+        className
+      )}
+      data-count={activity.count}
+      data-date={activity.date}
+      data-level={activity.level}
+      height={blockSize}
+      rx={blockRadius}
+      ry={blockRadius}
+      width={blockSize}
+      x={(blockSize + blockMargin) * weekIndex}
+      y={labelHeight + (blockSize + blockMargin) * dayIndex}
+      {...props}
+    />
+  );
+};
+
+export type ContributionGraphCalendarProps = Omit<
+  HTMLAttributes<HTMLDivElement>,
+  "children"
+> & {
+  hideMonthLabels?: boolean;
+  className?: string;
+  children: (props: {
+    activity: Activity;
+    dayIndex: number;
+    weekIndex: number;
+  }) => ReactNode;
+};
+
+export const ContributionGraphCalendar = ({
+  hideMonthLabels = false,
+  className,
+  children,
+  ...props
+}: ContributionGraphCalendarProps) => {
+  const { weeks, width, height, blockSize, blockMargin, labels } =
+    useContributionGraph();
+
+  const monthLabels = useMemo(
+    () => getMonthLabels(weeks, labels.months),
+    [weeks, labels.months]
+  );
+
+  return (
+    <div
+      className={cn("max-w-full overflow-x-auto overflow-y-hidden", className)}
+      {...props}
+    >
+      <svg
+        className="block overflow-visible"
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        width={width}
+      >
+        <title>Contribution Graph</title>
+        {!hideMonthLabels && (
+          <g className="fill-current">
+            {monthLabels.map(({ label, weekIndex }) => (
+              <text
+                dominantBaseline="hanging"
+                key={weekIndex}
+                x={(blockSize + blockMargin) * weekIndex}
+              >
+                {label}
+              </text>
+            ))}
+          </g>
+        )}
+        {weeks.map((week, weekIndex) =>
+          week.map((activity, dayIndex) => {
+            if (!activity) {
+              return null;
+            }
+
+            return (
+              <Fragment key={`${weekIndex}-${dayIndex}`}>
+                {children({ activity, dayIndex, weekIndex })}
+              </Fragment>
+            );
+          })
+        )}
+      </svg>
+    </div>
+  );
+};
+
+export type ContributionGraphFooterProps = HTMLAttributes<HTMLDivElement>;
+
+export const ContributionGraphFooter = ({
+  className,
+  ...props
+}: ContributionGraphFooterProps) => (
+  <div
+    className={cn(
+      "flex flex-wrap gap-1 whitespace-nowrap sm:gap-x-4",
+      className
+    )}
+    {...props}
+  />
+);
+
+export type ContributionGraphTotalCountProps = Omit<
+  HTMLAttributes<HTMLDivElement>,
+  "children"
+> & {
+  children?: (props: { totalCount: number; year: number }) => ReactNode;
+};
+
+export const ContributionGraphTotalCount = ({
+  className,
+  children,
+  ...props
+}: ContributionGraphTotalCountProps) => {
+  const { totalCount, year, labels } = useContributionGraph();
+
+  if (children) {
+    return <>{children({ totalCount, year })}</>;
+  }
+
+  return (
+    <div className={cn("text-muted-foreground", className)} {...props}>
+      {labels.totalCount
+        ? labels.totalCount
+            .replace("{{count}}", String(totalCount))
+            .replace("{{year}}", String(year))
+        : `${totalCount} activities in ${year}`}
+    </div>
+  );
+};
+
+export type ContributionGraphLegendProps = Omit<
+  HTMLAttributes<HTMLDivElement>,
+  "children"
+> & {
+  children?: (props: { level: number }) => ReactNode;
+};
+
+export const ContributionGraphLegend = ({
+  className,
+  children,
+  ...props
+}: ContributionGraphLegendProps) => {
+  const { labels, maxLevel, blockSize, blockRadius } = useContributionGraph();
+
+  return (
+    <div
+      className={cn("ml-auto flex items-center gap-[3px]", className)}
+      {...props}
+    >
+      <span className="mr-1 text-muted-foreground">
+        {labels.legend?.less || "Less"}
+      </span>
+      {new Array(maxLevel + 1).fill(undefined).map((_, level) =>
+        children ? (
+          <Fragment key={level}>{children({ level })}</Fragment>
+        ) : (
+          <svg height={blockSize} key={level} width={blockSize}>
+            <title>{`${level} contributions`}</title>
+            <rect
+              className={cn(
+                "stroke-[1px] stroke-border",
+                'data-[level="0"]:fill-muted',
+                'data-[level="1"]:fill-muted-foreground/20',
+                'data-[level="2"]:fill-muted-foreground/40',
+                'data-[level="3"]:fill-muted-foreground/60',
+                'data-[level="4"]:fill-muted-foreground/80'
+              )}
+              data-level={level}
+              height={blockSize}
+              rx={blockRadius}
+              ry={blockRadius}
+              width={blockSize}
+            />
+          </svg>
+        )
+      )}
+      <span className="ml-1 text-muted-foreground">
+        {labels.legend?.more || "More"}
+      </span>
+    </div>
+  );
+};

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"@radix-ui/react-tooltip": "^1.2.7",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
+		"date-fns": "^4.1.0",
 		"framer-motion": "^12.23.9",
 		"gray-matter": "^4.0.3",
 		"highlight.js": "^11.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       framer-motion:
         specifier: ^12.23.9
         version: 12.23.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)


### PR DESCRIPTION
This pull request refactors how GitHub contribution data is fetched and displayed on the homepage, replacing the previous calendar component with a new custom contribution graph. It introduces server-side caching for API requests, improves type safety, and updates dependencies to support the new implementation.

**GitHub Contributions Display Refactor:**

* Replaced the old `GitHubCalendar` component with a new custom `Contributions` component, which uses a more flexible and styled contribution graph built from primitives in `kibo-ui/contribution-graph`. This allows for better customization and visual consistency. [[1]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L31-R51) [[2]](diffhunk://#diff-9570e99a1e816b43c4281656089c67c42a974730d52bc03aeb047fbc4dab9553R1-R61)
* Removed the client-side filtering logic (`selectLastNMonths`) and now fetches and processes contribution data server-side using `unstable_cache` for efficient caching and reduced API calls. [[1]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L1-L11) [[2]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L193-L203)

**Codebase and Dependency Updates:**

* Added the `date-fns` library to dependencies, likely for improved date manipulation in the new contribution graph. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R20) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR32-R34)

**Type Safety and Imports:**

* Updated imports to use type-safe definitions for `Activity` and contribution graph components, improving maintainability and reducing runtime errors. [[1]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L1-L11) [[2]](diffhunk://#diff-9570e99a1e816b43c4281656089c67c42a974730d52bc03aeb047fbc4dab9553R1-R61)